### PR TITLE
Refactor: TaskInput 에서 엔터 키 입력 이벤트 추가 및 각 컴포넌트 디자인 변경

### DIFF
--- a/src/app/(main)/_component/TaskInput.module.css
+++ b/src/app/(main)/_component/TaskInput.module.css
@@ -16,6 +16,7 @@
 
 .search>input {
     flex-grow: 1;
+    height: 24px;
     margin: 0 20px;
 }
 

--- a/src/app/(main)/_component/TaskInput.module.css
+++ b/src/app/(main)/_component/TaskInput.module.css
@@ -15,9 +15,11 @@
 }
 
 .search>input {
+    margin: 0 20px;
     flex-grow: 1;
     height: 24px;
-    margin: 0 20px;
+    font-size: 14px;
+        font-weight: 400;
 }
 
 /* button */

--- a/src/app/(main)/_component/TaskInput.tsx
+++ b/src/app/(main)/_component/TaskInput.tsx
@@ -38,6 +38,12 @@ export default function TaskInput({ onClick }: IProps) {
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>, value: string) => {
+    if (e.key === 'Enter') {
+      handleClick(value);
+    }
+  };
+
   useEffect(() => {
     setError(undefined);
   }, [task]);
@@ -45,7 +51,12 @@ export default function TaskInput({ onClick }: IProps) {
   return (
     <div className={cx('search-wrapper')}>
       <div className={cx('search')}>
-        <input placeholder="Add your task" value={task} onChange={e => setTask(e.currentTarget.value)} />
+        <input
+          placeholder="Add your task"
+          value={task}
+          onChange={e => setTask(e.currentTarget.value)}
+          onKeyDown={e => handleKeyDown(e, task)}
+        />
         <button
           className={cx('button-item')}
           onClick={() => handleClick(task)}

--- a/src/app/(main)/_component/TodoItem.module.css
+++ b/src/app/(main)/_component/TodoItem.module.css
@@ -25,7 +25,7 @@
 
 /* checkbox text */
 .text {
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 400;
     transition: text-decoration 0.3s;
     margin-left: 8px;

--- a/src/app/(main)/page.module.css
+++ b/src/app/(main)/page.module.css
@@ -1,1 +1,6 @@
-.container {}
+.container {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+}

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -2,7 +2,7 @@ import classNames from 'classnames/bind';
 
 import TodoContainer from './_component/TodoContainer';
 
-import styles from './layout.module.css';
+import styles from './page.module.css';
 
 const cx = classNames.bind(styles);
 


### PR DESCRIPTION
# 해결하려는 문제가 무엇인가요?
* 어색한 스타일 수정 필요
* Todo Container 중앙 배치 필요
* Task 입력 시, 마우스로 ADD 버튼을 클릭해야만 추가가 되는 불편함 개선 필요

# 어떻게 해결했나요?
* 각 스타일 정보 변경
* Todo Container 중앙 배치
* Task 입력 시, 엔터키를 눌러도 Todo-list가 추가되도록 변경

## Attachment
![image](https://github.com/user-attachments/assets/be5a853d-8f71-49f4-b74b-67fdd5affcae)
